### PR TITLE
Update FilePicker.swift

### DIFF
--- a/Sources/FilePicker/FilePicker.swift
+++ b/Sources/FilePicker/FilePicker.swift
@@ -83,7 +83,7 @@ public struct FilePicker<LabelView: View>: View {
             if presented == true {
                 let panel = NSOpenPanel()
                 panel.allowsMultipleSelection = allowMultiple
-                panel.canChooseDirectories = false
+                panel.canChooseDirectories = types.contains(.directory) // should be able to choose directories it the type is included
                 panel.canChooseFiles = true
                 panel.allowedFileTypes = types.map { $0.identifier }
                 panel.begin { reponse in


### PR DESCRIPTION
added ability to choose directories.

if the types-array passed to the FilePicker initialiser contains .directory, the user should be able to pick directories. Alas, the current code never lets that happen.